### PR TITLE
Update extensions to avoid warning

### DIFF
--- a/lib/active_record/postgres_enum/extensions.rb
+++ b/lib/active_record/postgres_enum/extensions.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       module ColumnMethods # :nodoc:
         # Enables `t.enum :my_field, enum_name: :my_enum_name` on migrations
         def enum(name, options = {})
-          column(name, options.delete(:enum_name), options.except(:enum_name))
+          column(name, options.delete(:enum_name), **options.except(:enum_name))
         end
       end
     end


### PR DESCRIPTION
Update extensions to avoid warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
